### PR TITLE
Removed generated sequence from Batch bean. This was overriding the i…

### DIFF
--- a/BAM/src/main/java/com/revature/bam/bean/Batch.java
+++ b/BAM/src/main/java/com/revature/bam/bean/Batch.java
@@ -26,8 +26,6 @@ public class Batch {
 
 	@Id
 	@Column(name = "BATCH_ID")
-	@SequenceGenerator(name = "BATCH_ID_SEQ", sequenceName = "BATCH_ID_SEQ")
-	@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "BATCH_ID_SEQ")
 	private Integer id;
 
 	@Column(name = "BATCH_NAME")


### PR DESCRIPTION
…d from assignforce during sync, causing new entries to be added to DB rather than updating the existing batch entries. Syncing should no longer create duplicate batches.